### PR TITLE
Updated Flickr URL regex

### DIFF
--- a/coffee/bookmarklet.coffee
+++ b/coffee/bookmarklet.coffee
@@ -3,7 +3,7 @@ server = 'http://jarred.github.com/src-img/'
 analyticsID = 'UA-4516491-29'
 
 libs = [
-  'http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js'
+  'http://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js'
   'http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.1.7/underscore-min.js'
   "#{server}/js/lib/URI.js"
   # "http://www.google-analytics.com/u/ga_debug.js"  
@@ -58,7 +58,7 @@ sourceImage =
       if src.indexOf 'http' < 0
         src = absolutizeURI window.location, src
         
-      flickrID = /static.flickr.com\/([0-9]*)\/([0-9]*)/i.exec(src);
+      flickrID = /static.?flickr.com\/([0-9]*)\/([0-9]*)/i.exec(src);
       
       if flickrID
         searchUrl = "http://www.flickr.com/photo.gne?id=" + flickrID[2];

--- a/coffee/main.coffee
+++ b/coffee/main.coffee
@@ -2,6 +2,7 @@ srcImg = window.SrcImg ||= {}
 
 srcImg.Main =
   # server: 'http://localhost:4104'
+  # server: 'http://localhost:8000'
   server: 'http://jarred.github.com/src-img'
   version: 0.57
   

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       <a href="#">&nbsp;</a>
     </div>
     <p>Then click it when you are on a page with images you want to track down.</p>
-    <p class="footer">&#9810; This bookmarklet is brought to you by <a href="http://twitter.com/jarred">@jarred</a> &amp; <a href="hydnhntr">@hydnhntr</a> and is in no way afilliated with Google&trade;. Found a bug? <a href="http://github.com/jarred/src-img/">Fix it.</p></p>
+    <p class="footer">&#9810; This bookmarklet is brought to you by <a href="http://twitter.com/jarred">@jarred</a> &amp; <a href="http://twitter.com/hydnhntr">@hydnhntr</a> and is in no way afilliated with Google&trade;. Found a bug? <a href="http://github.com/jarred/src-img/">Fix it.</p></p>
   </div> 
   
   <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>

--- a/js/app/bookmarklet.js
+++ b/js/app/bookmarklet.js
@@ -1,9 +1,12 @@
 (function() {
   var analyticsID, checkForRequire, libs, loadLibs, server, sourceImage;
-  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
+
   server = 'http://jarred.github.com/src-img/';
+
   analyticsID = 'UA-4516491-29';
-  libs = ['http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js', 'http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.1.7/underscore-min.js', "" + server + "/js/lib/URI.js", "http://www.google-analytics.com/ga.js"];
+
+  libs = ['http://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js', 'http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.1.7/underscore-min.js', "" + server + "/js/lib/URI.js", "http://www.google-analytics.com/ga.js"];
+
   sourceImage = {
     exit: function(e) {
       $('a.src-img').remove();
@@ -14,7 +17,8 @@
       _gaq.push(['src-img-tracker._trackEvent', 'site', 'click', window.location.hostname]);
     },
     init: function() {
-      var $style, close, count;
+      var $style, close, count,
+        _this = this;
       $style = $('<link>');
       $style.attr({
         rel: 'stylesheet',
@@ -27,25 +31,21 @@
       });
       _gaq.push(['src-img-tracker._trackEvent', 'site', 'open', window.location.hostname]);
       count = 0;
-      $.each($('img'), __bind(function(index, img) {
+      $.each($('img'), function(index, img) {
         var $img, flickrID, searchUrl, src;
         $img = $(img);
-        if ($img.height() < 100 || $img.width() < 100) {
-          return;
-        }
+        if ($img.height() < 100 || $img.width() < 100) return;
         count++;
         src = $img.attr('src');
-        if (src.indexOf('http' < 0)) {
-          src = absolutizeURI(window.location, src);
-        }
-        flickrID = /static.flickr.com\/([0-9]*)\/([0-9]*)/i.exec(src);
+        if (src.indexOf('http' < 0)) src = absolutizeURI(window.location, src);
+        flickrID = /static.?flickr.com\/([0-9]*)\/([0-9]*)/i.exec(src);
         if (flickrID) {
           searchUrl = "http://www.flickr.com/photo.gne?id=" + flickrID[2];
         } else {
           searchUrl = "http://images.google.com/searchbyimage?image_url=" + (escape(src)) + "&image_content=&bih=" + ($img.height()) + "&biw=" + ($img.width());
         }
         $('body').append("      <a class=\"src-img\" style=\"width:" + ($img.width()) + "px;height:" + ($img.height()) + "px;top:" + ($img.offset().top) + "px;left:" + ($img.offset().left) + "px;\" href=\"" + searchUrl + "\" target=\"_blank\"><span>&#63;&iquest;</span></a>      ");
-      }, this));
+      });
       $('a.src-img').bind('click', this.trackClick);
       if (count === 0) {
         alert('I couldn\'t find any images :(');
@@ -56,11 +56,13 @@
       $(close).bind('click', this.exit);
     }
   };
+
   loadLibs = function() {
     require(libs, function() {
       sourceImage.init();
     });
   };
+
   checkForRequire = function() {
     if (typeof require !== "undefined" && require !== null) {
       loadLibs();
@@ -69,5 +71,7 @@
       this.requireInt = setTimeout(checkForRequire, 100);
     }
   };
+
   checkForRequire();
+
 }).call(this);

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -1,6 +1,8 @@
 (function() {
   var srcImg;
+
   srcImg = window.SrcImg || (window.SrcImg = {});
+
   srcImg.Main = {
     server: 'http://jarred.github.com/src-img',
     version: 0.57,
@@ -12,5 +14,7 @@
       $('div.bookmarklet-hold').html("<a href=\"javascript:void((function(){var sir=document.createElement('script');sir.setAttribute('src','http://cdnjs.cloudflare.com/ajax/libs/require.js/0.26.0/require.min.js');sir.setAttribute('type','text/javascript');document.getElementsByTagName('head')[0].appendChild(sir);var sib=document.createElement('script');sib.setAttribute('src','" + this.server + "/js/app/bookmarklet.js?version=" + this.version + "');sib.setAttribute('type','text/javascript');document.getElementsByTagName('head')[0].appendChild(sib);})());\"><u>&#63;</u>&iquest;<u> src-im</u>g</a>");
     }
   };
+
   srcImg.Main.init();
+
 }).call(this);

--- a/test/index.html
+++ b/test/index.html
@@ -48,5 +48,10 @@
 		<img src="http://farm4.static.flickr.com/3074/2908803730_d632baaa6e_b.jpg" alt="GT by Citroën — Laurent Nivalle"/>
 		<p>Flickr Image</p>
 	</div>
+	
+	<div class="test">
+		<img src="http://farm4.staticflickr.com/3405/3485555712_80e234fe9b_b.jpg" alt="abc verlag_publicity and graphic design in the chemical industry (24/91)"/>
+		<p>staticflickr.com Image</p>
+	</div>
 </body>
 </html>


### PR DESCRIPTION
Now supports *.static.flickr.com and *.staticflickr.com

Updated to jQuery 1.7.1, fixed HH Twitter reference and added a new test
