### PR TITLE
Fix insecure content errors over HTTPS 

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
     <p class="footer">&#9810; This bookmarklet is brought to you by <a href="http://twitter.com/jarred">@jarred</a> &amp; <a href="http://twitter.com/hydnhntr">@hydnhntr</a> and is in no way afilliated with Google&trade;. Found a bug? <a href="http://github.com/jarred/src-img/">Fix it.</p></p>
   </div> 
   
-  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
-  <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.1.7/underscore-min.js"></script>
+  <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
+  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.1.7/underscore-min.js"></script>
   <script type="text/javascript" src="./js/app/main.js"></script>
   
   <script type="text/javascript">

--- a/js/app/bookmarklet.js
+++ b/js/app/bookmarklet.js
@@ -1,7 +1,7 @@
 (function() {
   var analyticsID, checkForRequire, libs, loadLibs, server, sourceImage;
 
-  server = '//raw.github.com/BrainCrumbz/src-img/master';
+  server = 'http://jarred.github.com/src-img/';
 
   analyticsID = 'UA-4516491-29';
 

--- a/js/app/bookmarklet.js
+++ b/js/app/bookmarklet.js
@@ -1,7 +1,7 @@
 (function() {
   var analyticsID, checkForRequire, libs, loadLibs, server, sourceImage;
 
-  server = '//github.com/BrainCrumbz/src-img/';
+  server = '//raw.github.com/BrainCrumbz/src-img/master';
 
   analyticsID = 'UA-4516491-29';
 

--- a/js/app/bookmarklet.js
+++ b/js/app/bookmarklet.js
@@ -1,7 +1,7 @@
 (function() {
   var analyticsID, checkForRequire, libs, loadLibs, server, sourceImage;
 
-  server = 'http://jarred.github.com/src-img/';
+  server = '//jarred.github.com/src-img/';
 
   analyticsID = 'UA-4516491-29';
 

--- a/js/app/bookmarklet.js
+++ b/js/app/bookmarklet.js
@@ -1,11 +1,11 @@
 (function() {
   var analyticsID, checkForRequire, libs, loadLibs, server, sourceImage;
 
-  server = 'http://jarred.github.com/src-img/';
+  server = '//github.com/BrainCrumbz/src-img/';
 
   analyticsID = 'UA-4516491-29';
 
-  libs = ['http://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js', 'http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.1.7/underscore-min.js', "" + server + "/js/lib/URI.js", "http://www.google-analytics.com/ga.js"];
+  libs = ['//ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js', '//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.1.7/underscore-min.js', "" + server + "/js/lib/URI.js", "//www.google-analytics.com/ga.js"];
 
   sourceImage = {
     exit: function(e) {

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -4,7 +4,7 @@
   srcImg = window.SrcImg || (window.SrcImg = {});
 
   srcImg.Main = {
-    server: '//raw.github.com/BrainCrumbz/src-img/master',
+    server: 'http://jarred.github.com/src-img',
     version: 0.66,
     init: function() {
       _.bindAll(this);

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -4,7 +4,7 @@
   srcImg = window.SrcImg || (window.SrcImg = {});
 
   srcImg.Main = {
-    server: '//github.com/BrainCrumbz/src-img',
+    server: '//raw.github.com/BrainCrumbz/src-img/master',
     version: 0.66,
     init: function() {
       _.bindAll(this);

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -4,7 +4,7 @@
   srcImg = window.SrcImg || (window.SrcImg = {});
 
   srcImg.Main = {
-    server: 'http://jarred.github.com/src-img',
+    server: '//jarred.github.com/src-img',
     version: 0.66,
     init: function() {
       _.bindAll(this);

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -4,14 +4,14 @@
   srcImg = window.SrcImg || (window.SrcImg = {});
 
   srcImg.Main = {
-    server: 'http://jarred.github.com/src-img',
+    server: '//github.com/BrainCrumbz/src-img',
     version: 0.66,
     init: function() {
       _.bindAll(this);
       this.writeBookmarklet();
     },
     writeBookmarklet: function() {
-      $('div.bookmarklet-hold').html("<a href=\"javascript:void((function(){var sir=document.createElement('script');sir.setAttribute('src','http://cdnjs.cloudflare.com/ajax/libs/require.js/0.26.0/require.min.js');sir.setAttribute('type','text/javascript');document.getElementsByTagName('head')[0].appendChild(sir);var sib=document.createElement('script');sib.setAttribute('src','" + this.server + "/js/app/bookmarklet.js?version=" + this.version + "');sib.setAttribute('type','text/javascript');document.getElementsByTagName('head')[0].appendChild(sib);})());\"><u>&#63;</u>&iquest;<u> src-im</u>g</a>");
+      $('div.bookmarklet-hold').html("<a href=\"javascript:void((function(){var sir=document.createElement('script');sir.setAttribute('src','//cdnjs.cloudflare.com/ajax/libs/require.js/0.26.0/require.min.js');sir.setAttribute('type','text/javascript');document.getElementsByTagName('head')[0].appendChild(sir);var sib=document.createElement('script');sib.setAttribute('src','" + this.server + "/js/app/bookmarklet.js?version=" + this.version + "');sib.setAttribute('type','text/javascript');document.getElementsByTagName('head')[0].appendChild(sib);})());\"><u>&#63;</u>&iquest;<u> src-im</u>g</a>");
     }
   };
 


### PR DESCRIPTION
When an image URL is secure (i.e. with https scheme), bookmarklet fails to work and JavaScript console show following two errors (at least on Google Chrome):

[blocked] The page at 'https://whatever.jpg' was loaded over HTTPS, but ran insecure content from 'http://cdnjs.cloudflare.com/ajax/libs/require.js/0.26.0/require.min.js': this content should also be loaded over HTTPS.

[blocked] The page at 'https://whatever.jpg' was loaded over HTTPS, but ran insecure content from 'http://jarred.github.com/src-img/js/app/bookmarklet.js?version=0.66': this content should also be loaded over HTTPS.
